### PR TITLE
Setup custom wpfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,31 @@ Deployment for the CT wordpress instance(s) using terraform. Key components of t
 
 The WP module uses a docker-compose stack configuration to setup the wp server, database, etc on each docker instance, see `docker/full-stack.yml`. The docker-compose configuration points to a docker image `ctwp-wp` built from the `Dockerfile`.
 
+To deploy there are two steps required:
 
+1. Create a file called `terraform.tfvars` in the `/ctwp` directory. In it, you need to define three values:
+
+```
+do_token="<digital-ocean-api-token>"
+public_key_path="/path/to/public_key"
+private_key_path="/path/to/private/key"
+```
+
+The digital ocean API token must be acquired through the digital ocean site or via their api. The public and priate key paths point to an ssh key.
+
+Generate these key files with: `ssh-keygen -o -a 100 -t ssh-ed25519 -C ct@digitalocean`.
+
+2. Once these variables are defined, you should be able to deploy the infrastructure using this simple command:
+
+```
+terraform apply
+```
+
+To destroy the infrastructure, do:
+
+```
+terraform destroy
+```
 
 
 

--- a/ctwp/docker/full-stack.yml
+++ b/ctwp/docker/full-stack.yml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services:
   wp:
-    image: ezmiller/ctwp-wp:latest
+    image: wordpress:latest
     ports:
       - "8080:80"
     secrets:

--- a/ctwp/docker/stack_ctwp-v2.yml
+++ b/ctwp/docker/stack_ctwp-v2.yml
@@ -1,0 +1,34 @@
+version: '3.1'
+
+services:
+  wp:
+    image: wordpress:latest
+    ports:
+      - "8080:80"
+    volumes:
+      - ./wp-files/plugins:/var/www/html/wp-content/plugins
+    secrets:
+      - ctwp_db_password
+    environment:
+      WORDPRESS_DB_NAME: ctwp
+      WORDPRESS_DB_PASSWORD_FILE: /run/secrets/ctwp_db_password
+
+  mysql:
+    image: mysql:5.6
+    ports:
+      - 3306:3306
+    volumes:
+      - dbdata:/var/lib/mysql
+    secrets:
+      - ctwp_db_password
+    environment:
+      MYSQL_DATABASE: ctwp
+      MYSQL_ROOT_PASSWORD_FILE: /run/secrets/ctwp_db_password
+
+secrets:
+  ctwp_db_password:
+    external: true
+
+volumes:
+  dbdata:
+

--- a/ctwp/main.tf
+++ b/ctwp/main.tf
@@ -24,23 +24,25 @@ resource "digitalocean_ssh_key" "ct_key" {
   public_key = "${file(var.public_key_path)}"
 }
 
-module "ctwp-old" {
-  source           = "./modules/wp"
-  name             = "ctwp-old"
-  ssh_key_id       = "${digitalocean_ssh_key.ct_key.id}"
-  private_key_path = "${var.private_key_path}"
-  wp_db_path       = "./ctwp-2019-03-24-ac9f685.sql"
-}
+# module "ctwp-old" {
+#   source           = "./modules/wp"
+#   name             = "ctwp-old"
+#   ssh_key_id       = "${digitalocean_ssh_key.ct_key.id}"
+#   private_key_path = "${var.private_key_path}"
+#   wp_db_path       = "./ctwp-2019-03-24-ac9f685.sql"
+# }
 
-output "ctwp-old" {
-  value = "${module.ctwp-old.instance_public_ip}"
-}
+# output "ctwp-old" {
+#   value = "${module.ctwp-old.instance_public_ip}"
+# }
 
 module "ctwp-v2" {
-  source           = "./modules/wp"
-  name             = "ctwp-v2"
-  ssh_key_id       = "${digitalocean_ssh_key.ct_key.id}"
-  private_key_path = "${var.private_key_path}"
+  source            = "./modules/wp"
+  name              = "ctwp-v2"
+  docker_config     = "./docker/stack_ctwp-v2.yml"
+  wp_files          = "./wp-files/ctwp-v2/"
+  ssh_key_id        = "${digitalocean_ssh_key.ct_key.id}"
+  private_key_path  = "${var.private_key_path}"
 }
 
 output "ctwp-v2.public_ip" {

--- a/ctwp/modules/wp/main.tf
+++ b/ctwp/modules/wp/main.tf
@@ -19,8 +19,17 @@ resource "digitalocean_droplet" "wp" {
   }
 
   provisioner "file" {
-    source = "./docker/full-stack.yml"
-    destination = "./full-stack.yml"
+    source = "${var.docker_config}"
+    destination = "./stack.yml"
+  }
+
+  provisioner "remote-exec" {
+    inline = ["mkdir -p ./wp-files"]
+  }
+
+  provisioner "file" {
+    source = "${var.wp_files}" # path must include trailing /
+    destination = "./wp-files"
   }
 
   provisioner "file" {
@@ -45,7 +54,7 @@ resource "digitalocean_droplet" "wp" {
       "echo \"Deploying stack...\"",
       "docker swarm init --advertise-addr ${digitalocean_droplet.wp.ipv4_address_private}",
       "echo ${random_string.wp_db_password.result} | docker secret create ctwp_db_password -",
-      "docker stack up -c full-stack.yml ctwp",
+      "docker stack up -c stack.yml ctwp",
     ]
   }
 

--- a/ctwp/modules/wp/variables.tf
+++ b/ctwp/modules/wp/variables.tf
@@ -12,3 +12,13 @@ variable "wp_db_path" {
   description = "Path to the DB to load into the WP instance."
   default = ""
 }
+
+variable "wp_files" {
+  description = "Path to wordpress files for instance, if any"
+  default = ""
+}
+
+variable "docker_config" {
+  description = "Path to the YML config file for the docker stack"
+  default = "./docker/full-stack.yml"
+}

--- a/ctwp/scripts/wp-cli.sh
+++ b/ctwp/scripts/wp-cli.sh
@@ -19,4 +19,4 @@ $DOCKER_CMD run -it --rm \
             --volumes-from $WP_CONTAINER \
             --net container:$WP_CONTAINER \
             --name "wp-cli" \
-            wordpress:cli ${@:1}
+            wordpress:cli "${@:1}"

--- a/ctwp/wp-files/ctwp-v2/plugins/ctwp-defaults/ctwp-defaults.php
+++ b/ctwp/wp-files/ctwp-v2/plugins/ctwp-defaults/ctwp-defaults.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Plugin Name: CTWP Defaults
+ */
+
+function resource_custom_post_type()
+{
+    register_post_type('resource',
+                       array(
+                           'labels' => array(
+                               'name' => __('Resources'),
+                               'singular_name' => __('Resource')
+                           ),
+                           'public' => true,
+                           'has_archive' => true,
+                           'show_in_rest' => true,
+                           'supports' => array('title')
+                       )
+    );
+}
+add_action('init', 'resource_custom_post_type');
+?>


### PR DESCRIPTION
This PR resolves #2 adds the ability to put custom wp-files (e.g. plugins, templates etc) on the wordpress instance. The way to do this is to specify a custom docker stack config and path to wp-files in the module delecaration, e.g.:

```
module "ctwp-v2" {
  source            = "./modules/wp"
  name              = "ctwp-v2"
  docker_config     = "./docker/stack_ctwp-v2.yml"
  wp_files          = "./wp-files/ctwp-v2/"
  ssh_key_id        = "${digitalocean_ssh_key.ct_key.id}"
  private_key_path  = "${var.private_key_path}"
}
```

The `wp_files` path contains a directory struture mirroring the `wp-content` directory which you'd find in a wordpress install. The docker stack config can mount the specific directories like so, or you can just mount the whole directory

```yml
wp:
    ...
    volumes:
      - ./wp-files/plugins:/var/www/html/wp-content/plugins
    ...
```
But the point is that the volume mounted in the docker config needs to correspond with the `wp_files` path provided in the terraform module declaration.